### PR TITLE
changed name of repeated setSubscriptionId() function

### DIFF
--- a/contracts/Bull&Bear.sol
+++ b/contracts/Bull&Bear.sol
@@ -198,7 +198,7 @@ contract BullBear is ERC721, ERC721Enumerable, ERC721URIStorage, KeeperCompatibl
   }
 
 
-  function setSubscriptionId(uint32 maxGas) public onlyOwner {
+  function setSubscriptionGasLimit(uint32 maxGas) public onlyOwner {
       callbackGasLimit = maxGas;
   }
 


### PR DESCRIPTION
I was trying to add the setSubscriptionId() to the constructor, and noticed that it has the name repeated even tho it did different things. thus
setSubscriptionId() -> setSubscriptionGasLimit()